### PR TITLE
Change URL format

### DIFF
--- a/WallpaperManager.py
+++ b/WallpaperManager.py
@@ -26,7 +26,7 @@ def download_wallpaper(width=1600, height=900):
     # image url
     base_url = "https://source.unsplash.com"
     tags = get_tags()
-    image_url = base_url + "/category/" + category + "/" + str(width) + "x" + str(height) + "?" + tags
+    image_url = base_url + "/" + str(width) + "x" + str(height) + "?" + category + "," + tags
 
     # download image
     try:


### PR DESCRIPTION
It seems that unsplash has changed its URL format so that the old format with category doesn't work well. I simply move the "category" to the back and it works on my computer.